### PR TITLE
feat: In cleanCache task, allow to clean cache directly on a local machine as well (instead of through ssh connection)

### DIFF
--- a/gulp/config/cleanCache.js
+++ b/gulp/config/cleanCache.js
@@ -7,6 +7,29 @@ const paths = require('../paths');
  */
 module.exports = {
     cacheTypes: ['layout', 'block_html', 'full_page'],
+
+    /**
+     * magentoConnection: {
+     *   type: 'ssh',
+     *   host: string,
+     *   username: string,
+     *   privateKey: string,
+     *   path: string
+     * } | {
+     *   type: 'local',
+     *   path: string
+     * }
+     */
+    magentoConnection: {
+        type: 'ssh',
+        host: 'creativeshop.me',
+        username: 'magento2',
+        privateKey: path.resolve(
+            '../../../../../vagrant/ssh/creativeshop_vagrant.key'
+        ),
+        path: '/var/www/creativeshop/current',
+    },
+
     watch: [
         // Template files
         path.join(paths.dist, '**/*.{php,phtml,html,twig}'),


### PR DESCRIPTION
This PR:

1. moves hardcoded SSH connection settings from cleanCache task to cleanCache config
2. allows to define a "local" connection instead of ssh, so that the clean cache can be run on the local dev machine directly

To use the local connection functionality, you can modify the gulp config before registering the gulp tasks in your `theme-.../gulpfile.js`, like this:

```js
const gulp = require('gulp');
const path = require('path');
const MagesuiteRegistry = require('@creativestyle/magesuite-frontend-builder/registry');

const browserSyncSettings = require('@creativestyle/magesuite-frontend-builder/gulp/config/browserSync');
browserSyncSettings.browserSync.proxy.target = 'http://127.0.0.1:8080';

const cleanCacheSettings = require('@creativestyle/magesuite-frontend-builder/gulp/config/cleanCache');
cleanCacheSettings.magentoConnection = {
    type: 'local',
    path: path.resolve('../../../'),
};

gulp.registry(MagesuiteRegistry);
```

Thanks to this, you can have magento running on your own machine directly (without docker/vagrant), and the `yarn gulp watch` in your theme will clean the cache after any theme changes are done.