### PR TITLE
Allow theme in different vendor directory

### DIFF
--- a/gulp/parentAliases.js
+++ b/gulp/parentAliases.js
@@ -11,12 +11,13 @@ const traverseAliases = themePath => {
     );
 
     const parentMatch = themeXML.match(
-        /<parent>[a-z]+\/[^\-]+\-([a-z]+)<\/parent>/i
+        /<parent>([a-z]+)\/[^\-]+\-([a-z]+)<\/parent>/i
     );
 
     if (parentMatch) {
-        const parentName = parentMatch[1];
-        const parentPath = path.resolve(`../theme-${parentName}`);
+        const parentVendor = parentMatch[1]
+        const parentName = parentMatch[2];
+        const parentPath = path.resolve(`../../${parentVendor}/theme-${parentName}`);
 
         if (fs.existsSync(parentPath)) {
             const aliases = {

--- a/gulp/parentAliases.js
+++ b/gulp/parentAliases.js
@@ -15,7 +15,7 @@ const traverseAliases = themePath => {
     );
 
     if (parentMatch) {
-        const parentVendor = parentMatch[1]
+        const parentVendor = parentMatch[1].toLowerCase();
         const parentName = parentMatch[2];
         const parentPath = path.resolve(`../../${parentVendor}/theme-${parentName}`);
 


### PR DESCRIPTION
This PR will allow a theme to be placed outside the `creativestyle` directory, e.g. `anothercompany/theme-mytheme` as suggested in https://github.com/magesuite/theme-creativeshop/issues/73#issuecomment-826122061

This seems to work locally for me, please comment if there are more changes required.